### PR TITLE
Finalize 2-phase APPROVED/DECLINED webhook callbacks

### DIFF
--- a/src/Webhook/WebhookService.php
+++ b/src/Webhook/WebhookService.php
@@ -93,6 +93,14 @@ class WebhookService
             throw new \Exception('Cannot find order');
         }
 
+        if ($paymentStatus === IPayStatuses::STATUS_APPROVED && !$this->hasFailed()) {
+            $this->approve($paymentData);
+        }
+
+        if ($paymentStatus === IPayStatuses::STATUS_DECLINED) {
+            $this->decline($paymentData);
+        }
+
         if ($paymentStatus === IPayStatuses::STATUS_DEPOSITED && !$this->hasFailed()) {
             $this->capture($paymentData);
         }
@@ -109,6 +117,21 @@ class WebhookService
         $this->orderService->updateOrderStatus($orderId);
 
         return true;
+    }
+
+    private function approve(BTIPayPayment $paymentData)
+    {
+        $paymentData->status = IPayStatuses::STATUS_APPROVED;
+        $this->paymentRepository->save($paymentData);
+    }
+
+    private function decline(BTIPayPayment $paymentData)
+    {
+        if (!in_array($paymentData->status, [IPayStatuses::STATUS_PENDING, IPayStatuses::STATUS_CREATED], true)) {
+            return;
+        }
+        $paymentData->status = IPayStatuses::STATUS_DECLINED;
+        $this->paymentRepository->save($paymentData);
     }
 
     private function capture(BTIPayPayment $paymentData)


### PR DESCRIPTION
When a customer pays in 2-phase mode (`registerPreAuth`) and does not return
to the shop after authentication, the webhook is the only mechanism that
finalizes the order. The webhook handler previously only persisted a status
for `DEPOSITED`, `REVERSED`, `REFUNDED`, and `PARTIALLY_REFUNDED` — there
was no branch for `APPROVED` or `DECLINED`. The payment row stayed at its
initial `PENDING`, the order state mapping resolved to "Awaiting BT iPay
payment" (the order's current state), and the order never advanced.

### Fix

Two new branches in `WebhookService::executeWebhook()`, plus two helpers:

- `approve()` — persists `STATUS_APPROVED` on `operation=approved`.
  The order then advances to "Authorized BT iPay. Awaiting Capture."
- `decline()` — persists `STATUS_DECLINED` on `operation=declined`.
  The order then advances to "Payment error" (`PS_OS_ERROR`).

A declined authorization arrives with `status=0` (so `hasFailed()` is true
by design); the decline branch therefore is intentionally not gated by
`!hasFailed()`. To prevent a duplicate or out-of-order decline from
downgrading an order that has already been approved or captured, the
decline helper only writes when the stored payment status is still
`PENDING` or `CREATED`.

`OrderService::mapStatusToOrderState()` already mapped both statuses;
those mappings were simply never reached because the statuses were never
stored.

`CREATED`, `PENDING`, and `VALIDATION_FINISHED` remain unhandled on
purpose — they are non-terminal and correctly leave the order in
Awaiting for retry.

### Status coverage after fix

| Operation                | Order outcome                |
|--------------------------|------------------------------|
| CREATED / PENDING / VF   | stays Awaiting (correct)     |
| APPROVED                 | Authorized, Awaiting Capture |
| DECLINED                 | Payment error                |
| DEPOSITED                | Payment accepted             |
| REVERSED                 | Canceled                     |
| REFUNDED / PARTIALLY_REF | refund states                |
